### PR TITLE
Grype PR Feedback

### DIFF
--- a/docs/styles/Vocab/SDP/accept.txt
+++ b/docs/styles/Vocab/SDP/accept.txt
@@ -41,3 +41,6 @@ Splunk
 [Dd]ockerfiles?
 Anchore
 [Pp]arsable
+[gG]rype
+(json|JSON)
+(cli|CLI)

--- a/libraries/grype/README.md
+++ b/libraries/grype/README.md
@@ -8,19 +8,30 @@ Uses the [Grype CLI](https://github.com/anchore/grype) to scan container images 
 
 ## Steps
 
-| Step | Description |
-|------|-------------|
-|   container_image_scan()   | Performs the Grype scan against your scaffold build image.             |
+| Step                   | Description                                                |
+|------------------------|------------------------------------------------------------|
+| container_image_scan() | Performs the Grype scan against your scaffold build image. |
 
 ## Configuration
 
-| Library Configuration | Type | Default Value |
-|-----------------------|------|---------------|
-| grype_container | String | grype:0.38.0 |
-| output_format | String | json |
-| fail_on_severity | String | high |
+| Library Configuration | Description                                              | Type   | Default Value | Options                                           |
+|-----------------------|----------------------------------------------------------|--------|---------------|---------------------------------------------------|
+| `grype_container`     | The container image to execute the scan within           | String | grype:0.38.0  |                                                   |
+| `report_format`       | The output format of the generated report                | String | json          | `json`, `table`, `cyclonedx`, `template`          |
+| `fail_on_severity`    | The severity level threshold that will fail the pipeline | String | high          | `negligible`, `low`, `medium`, `high`, `critical` |
+| `grype_config`        | A custom path to a grype configuration file              | String | `null`        |                                                   |
+
+## Grype Configuration File
+
+If `grype_config` isn't provided, the default locations for an application are `.grype.yaml`, `.grype/config.yaml`.
+
+!!! note "Learn More About Grype Configuration"
+
+    Read [the grype docs](https://github.com/anchore/grype#configuration) to learn more about the Grype configuration file
 
 ## Dependencies
 
 ---
-* docker is required to be installed on your grype container. The packages needed are docker-ce, docker-ce-cli and containerd.io.
+
+* This library requires that the `docker` library also be loaded and `build()` be invoked before `container_image_scan()`
+* If the default `grype_container` is replaced, it must be able to run docker containers (packages: docker-ce, docker-ce-cli and containerd.io).

--- a/libraries/grype/library_config.groovy
+++ b/libraries/grype/library_config.groovy
@@ -1,8 +1,8 @@
 fields{
     optional{
         grype_container = String
-        report_format = String
-        fail_on_severity = String
+        report_format = ["json", "table", "cyclonedx", "template"]
+        fail_on_severity = ["negligible", "low", "medium", "high", "critical"]
         grype_config = String
     }
 }

--- a/libraries/grype/test/ContainerImageScanSpec.groovy
+++ b/libraries/grype/test/ContainerImageScanSpec.groovy
@@ -7,7 +7,7 @@ package libraries.grype
 import JTEPipelineSpecification
 
 
-public class ContainerImageScanTestSpec extends JTEPipelineSpecification {
+public class ContainerImageScanSpec extends JTEPipelineSpecification {
 
     def ContainerImageScan = null
 
@@ -180,7 +180,7 @@ public class ContainerImageScanTestSpec extends JTEPipelineSpecification {
             1 * getPipelineMock("echo")("Failed: java.lang.Exception: test")
             1 * getPipelineMock("echo")("Grype Quality Gate Failed. There are one or more CVE's that exceed the maximum allowed severity rating!")
             1 * getPipelineMock("stash")("workspace")
-            thrown java.lang.Exception            
+            1 * getPipelineMock("error")(_)          
     }
 }
 


### PR DESCRIPTION
# PR Details

Documentation Updates:
* the docs didn't accurately reflect the library configurations the step was looking for
* added files that failed the Vale spell checking to the `accept.txt` file
* the dependencies didn't specify `docker` as a prerequisite
* the docs didn't tell users the default possible locations for a grype configuration file 
* the library configuration table didn't have a description column explaining what the configurations actually do
* used the markdown table extension in vscode to prettify the tables. makes them easier to read. 

Code Updates:
* Removed `List<Exception> errors` in favor of a `boolean shouldFail` flag. The exceptions were being stored on a list but then not actually being used for anything. 
* Instead of throwing an exception to fail the build, switched to the more idiomatic `error` step from Jenkins
* Updated the `library_config.groovy` to be more specific for the allowed values of the report format and failure threshold based on the grype CLI docs
* moved some variables closer to where they're actually being used so the code is easier to read 

Test Updates:
* renamed the test file from `ContainerImageScanTestSpec` to `ContainerImageScanSpec`.  `TestSpec` is redundant :). 